### PR TITLE
Added getOthersAtSameDepth method

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -801,6 +801,18 @@ abstract class Node extends Model
     }
 
     /**
+    * Retrieve all other nodes at the same depth,
+    *
+    * @return \Illuminate\Database\Eloquent\Collection
+    */
+    public function getOthersAtSameDepth()
+    {
+        return $this->newNestedSetQuery()
+                    ->where($this->getDepthColumnName(), '=', $this->getDepth())
+                    ->withoutSelf();
+    }
+
+    /**
     * Set of all children & nested children.
     *
     * @return \Illuminate\Database\Query\Builder

--- a/tests/suite/Category/CategoryColumnsTest.php
+++ b/tests/suite/Category/CategoryColumnsTest.php
@@ -145,4 +145,16 @@ class CategoryColumnsTest extends CategoryTestCase
         $category = new OrderedCategory();
         $this->assertFalse($category->isScoped());
     }
+
+    public function testGetOthersAtSameDepth()
+    {
+        $this->assertEquals(1, $this->categories('Root 1')->getOthersAtSameDepth()->count());
+        $this->assertEquals('Root 2', $this->categories('Root 1')->getOthersAtSameDepth()->first()->name);
+        
+        $this->assertEquals(2, $this->categories('Child 1')->getOthersAtSameDepth()->count());
+        $this->assertEquals(0, $this->categories('Child 2.1')->getOthersAtSameDepth()->count());
+        
+        $this->assertEquals('Child 2', $this->categories('Child 1')->getOthersAtSameDepth()->get()[0]->name);
+        $this->assertEquals('Child 3', $this->categories('Child 1')->getOthersAtSameDepth()->get()[1]->name);
+    }
 }


### PR DESCRIPTION
Was using the baum package and needed to grab the other nodes at the same depth and found it didn't have a method to do that so here it is.