### PR TITLE
Fix: make tree properly reorder items on same depth level

### DIFF
--- a/src/Baum/SetMapper.php
+++ b/src/Baum/SetMapper.php
@@ -116,6 +116,10 @@ class SetMapper
                 return false;
             }
 
+            if (!$node->isRoot()) {
+                $node->makeLastChildOf($node->parent);
+            }
+
             $affectedKeys[] = $node->getKey();
 
             if (array_key_exists($this->getChildrenKeyName(), $attributes)) {


### PR DESCRIPTION
I've noticed that makeTree doesn't re-order existing item.
If the tests aren't covering all use cases just let me know, I'll try to correct them.