### PR TITLE
Add symbol option to getNestedList method

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ It expects the column name to return, and optionally: the column
 to use for array keys (will use `id` if none supplied) and/or a separator:
 
 ```php
-public static function getNestedList($column, $key = null, $seperator = ' ');
+public static function getNestedList($column, $key = null, $seperator = ' ', $symbol = '');
 ```
 
 An example use case:

--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -1312,7 +1312,7 @@ abstract class Node extends Model
     *
     * @return Array
     */
-    public static function getNestedList($column, $key = null, $seperator = ' ')
+    public static function getNestedList($column, $key = null, $seperator = ' ', $symbol = '')
     {
         $instance = new static;
 
@@ -1323,8 +1323,8 @@ abstract class Node extends Model
 
         return array_combine(array_map(function ($node) use ($key) {
             return $node[$key];
-        }, $nodes), array_map(function ($node) use ($seperator, $depthColumn,$column) {
-            return str_repeat($seperator, $node[$depthColumn]).$node[$column];
+        }, $nodes), array_map(function ($node) use ($seperator, $depthColumn, $column, $symbol) {
+            return str_repeat($seperator, $node[$depthColumn]) . $symbol . $node[$column];
         }, $nodes));
     }
 

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -772,12 +772,12 @@ class CategoryHierarchyTest extends CategoryTestCase
         $nestedList = Category::getNestedList('name', 'id', $seperator, '- ');
 
         $expected = [
-      1 => str_repeat($seperator, 0).'Root 1',
+      1 => str_repeat($seperator, 0).'- Root 1',
       2 => str_repeat($seperator, 1).'- Child 1',
       3 => str_repeat($seperator, 1).'- Child 2',
       4 => str_repeat($seperator, 2).'- Child 2.1',
       5 => str_repeat($seperator, 1).'- Child 3',
-      6 => str_repeat($seperator, 0).'Root 2',
+      6 => str_repeat($seperator, 0).'- Root 2',
     ];
 
         $this->assertArraysAreEqual($expected, $nestedList);

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -752,7 +752,7 @@ class CategoryHierarchyTest extends CategoryTestCase
     public function testGetNestedList()
     {
         $seperator = ' ';
-        $nestedList = Category::getNestedList('name', 'id', $seperator, '');
+        $nestedList = Category::getNestedList('name', 'id', $seperator);
 
         $expected = [
       1 => str_repeat($seperator, 0).'Root 1',

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -768,16 +768,17 @@ class CategoryHierarchyTest extends CategoryTestCase
 
     public function testGetNestedListSymbol()
     {
+        $symbol = '- ';
         $seperator = ' ';
-        $nestedList = Category::getNestedList('name', 'id', $seperator, '- ');
+        $nestedList = Category::getNestedList('name', 'id', $seperator, $symbol);
 
         $expected = [
-      1 => str_repeat($seperator, 0).'- Root 1',
-      2 => str_repeat($seperator, 1).'- Child 1',
-      3 => str_repeat($seperator, 1).'- Child 2',
-      4 => str_repeat($seperator, 2).'- Child 2.1',
-      5 => str_repeat($seperator, 1).'- Child 3',
-      6 => str_repeat($seperator, 0).'- Root 2',
+      1 => str_repeat($seperator, 0).$symbol.'Root 1',
+      2 => str_repeat($seperator, 1).$symbol.'Child 1',
+      3 => str_repeat($seperator, 1).$symbol.'Child 2',
+      4 => str_repeat($seperator, 2).$symbol.'Child 2.1',
+      5 => str_repeat($seperator, 1).$symbol.'Child 3',
+      6 => str_repeat($seperator, 0).$symbol.'Root 2',
     ];
 
         $this->assertArraysAreEqual($expected, $nestedList);

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -752,7 +752,7 @@ class CategoryHierarchyTest extends CategoryTestCase
     public function testGetNestedList()
     {
         $seperator = ' ';
-        $nestedList = Category::getNestedList('name', 'id', $seperator);
+        $nestedList = Category::getNestedList('name', 'id', $seperator, '');
 
         $expected = [
       1 => str_repeat($seperator, 0).'Root 1',
@@ -760,6 +760,23 @@ class CategoryHierarchyTest extends CategoryTestCase
       3 => str_repeat($seperator, 1).'Child 2',
       4 => str_repeat($seperator, 2).'Child 2.1',
       5 => str_repeat($seperator, 1).'Child 3',
+      6 => str_repeat($seperator, 0).'Root 2',
+    ];
+
+        $this->assertArraysAreEqual($expected, $nestedList);
+    }
+
+    public function testGetNestedListSymbol()
+    {
+        $seperator = ' ';
+        $nestedList = Category::getNestedList('name', 'id', $seperator, '- ');
+
+        $expected = [
+      1 => str_repeat($seperator, 0).'Root 1',
+      2 => str_repeat($seperator, 1).'- Child 1',
+      3 => str_repeat($seperator, 1).'- Child 2',
+      4 => str_repeat($seperator, 2).'- Child 2.1',
+      5 => str_repeat($seperator, 1).'- Child 3',
       6 => str_repeat($seperator, 0).'Root 2',
     ];
 

--- a/tests/suite/Cluster/ClusterHierarchyTest.php
+++ b/tests/suite/Cluster/ClusterHierarchyTest.php
@@ -769,12 +769,12 @@ class ClusterHierarchyTest extends ClusterTestCase
         $nestedList = Cluster::getNestedList('name', 'id', $seperator, '- ');
 
         $expected = [
-      '7461d8f5-2ea9-4788-99c4-9d0244f0bfb1' => str_repeat($seperator, 0).'Root 1',
+      '7461d8f5-2ea9-4788-99c4-9d0244f0bfb1' => str_repeat($seperator, 0).'- Root 1',
       '5d7ce1fd-6151-46d3-a5b3-0ebb9988dc57' => str_repeat($seperator, 1).'- Child 1',
       '07c1fc8c-53b5-4fe7-b9c4-e09f266a455c' => str_repeat($seperator, 1).'- Child 2',
       '3315a297-af87-4ad3-9fa5-19785407573d' => str_repeat($seperator, 2).'- Child 2.1',
       '054476d2-6830-4014-a181-4de010ef7114' => str_repeat($seperator, 1).'- Child 3',
-      '3bb62314-9e1e-49c6-a5cb-17a9ab9b1b9a' => str_repeat($seperator, 0).'Root 2',
+      '3bb62314-9e1e-49c6-a5cb-17a9ab9b1b9a' => str_repeat($seperator, 0).'- Root 2',
     ];
 
         $this->assertArraysAreEqual($expected, $nestedList);

--- a/tests/suite/Cluster/ClusterHierarchyTest.php
+++ b/tests/suite/Cluster/ClusterHierarchyTest.php
@@ -762,4 +762,21 @@ class ClusterHierarchyTest extends ClusterTestCase
 
         $this->assertArraysAreEqual($expected, $nestedList);
     }
+
+    public function testGetNestedListSymbol()
+    {
+        $seperator = ' ';
+        $nestedList = Cluster::getNestedList('name', 'id', $seperator, '- ');
+
+        $expected = [
+      '7461d8f5-2ea9-4788-99c4-9d0244f0bfb1' => str_repeat($seperator, 0).'Root 1',
+      '5d7ce1fd-6151-46d3-a5b3-0ebb9988dc57' => str_repeat($seperator, 1).'- Child 1',
+      '07c1fc8c-53b5-4fe7-b9c4-e09f266a455c' => str_repeat($seperator, 1).'- Child 2',
+      '3315a297-af87-4ad3-9fa5-19785407573d' => str_repeat($seperator, 2).'- Child 2.1',
+      '054476d2-6830-4014-a181-4de010ef7114' => str_repeat($seperator, 1).'- Child 3',
+      '3bb62314-9e1e-49c6-a5cb-17a9ab9b1b9a' => str_repeat($seperator, 0).'Root 2',
+    ];
+
+        $this->assertArraysAreEqual($expected, $nestedList);
+    }
 }

--- a/tests/suite/Cluster/ClusterHierarchyTest.php
+++ b/tests/suite/Cluster/ClusterHierarchyTest.php
@@ -765,16 +765,17 @@ class ClusterHierarchyTest extends ClusterTestCase
 
     public function testGetNestedListSymbol()
     {
+        $symbol = '- ';
         $seperator = ' ';
-        $nestedList = Cluster::getNestedList('name', 'id', $seperator, '- ');
+        $nestedList = Cluster::getNestedList('name', 'id', $seperator, $symbol);
 
         $expected = [
-      '7461d8f5-2ea9-4788-99c4-9d0244f0bfb1' => str_repeat($seperator, 0).'- Root 1',
-      '5d7ce1fd-6151-46d3-a5b3-0ebb9988dc57' => str_repeat($seperator, 1).'- Child 1',
-      '07c1fc8c-53b5-4fe7-b9c4-e09f266a455c' => str_repeat($seperator, 1).'- Child 2',
-      '3315a297-af87-4ad3-9fa5-19785407573d' => str_repeat($seperator, 2).'- Child 2.1',
-      '054476d2-6830-4014-a181-4de010ef7114' => str_repeat($seperator, 1).'- Child 3',
-      '3bb62314-9e1e-49c6-a5cb-17a9ab9b1b9a' => str_repeat($seperator, 0).'- Root 2',
+      '7461d8f5-2ea9-4788-99c4-9d0244f0bfb1' => str_repeat($seperator, 0).$symbol.'Root 1',
+      '5d7ce1fd-6151-46d3-a5b3-0ebb9988dc57' => str_repeat($seperator, 1).$symbol.'Child 1',
+      '07c1fc8c-53b5-4fe7-b9c4-e09f266a455c' => str_repeat($seperator, 1).$symbol.'Child 2',
+      '3315a297-af87-4ad3-9fa5-19785407573d' => str_repeat($seperator, 2).$symbol.'Child 2.1',
+      '054476d2-6830-4014-a181-4de010ef7114' => str_repeat($seperator, 1).$symbol.'Child 3',
+      '3bb62314-9e1e-49c6-a5cb-17a9ab9b1b9a' => str_repeat($seperator, 0).$symbol.'Root 2',
     ];
 
         $this->assertArraysAreEqual($expected, $nestedList);


### PR DESCRIPTION
This change allows to set a custom symbol in the nested list set so you can create this:

An example use case:

``` php
$nestedList = Category::getNestedList('name', 'null', ' ', '- ');
// $nestedList will contain an array like the following:
// array(
//   1 => '- Root 1',
//   2 => ' - Child 1',
//   3 => ' - Child 2',
//   4 => '  - Child 2.1',
//   5 => ' - Child 3',
//   6 => '- Root 2'
// );
```
