### PR TITLE
Fix codestyle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "phpunit/phpunit": "4.*",
     "mockery/mockery": "~0.9",
     "d11wtq/boris": "~1.0.10",
-    "satooshi/php-coveralls": "dev-master"
+    "satooshi/php-coveralls": "dev-master",
+    "fabpot/php-cs-fixer": "^1.11"
   },
   "autoload": {
     "psr-0": {

--- a/src/Baum/Console/InstallCommand.php
+++ b/src/Baum/Console/InstallCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Baum\Console;
 
 use Baum\Generators\MigrationGenerator;
@@ -6,9 +7,9 @@ use Baum\Generators\ModelGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputArgument;
 
-class InstallCommand extends Command {
-
-  /**
+class InstallCommand extends Command
+{
+    /**
    * The console command name.
    *
    * @var string
@@ -23,29 +24,30 @@ class InstallCommand extends Command {
   protected $description = 'Scaffolds a new migration and model suitable for Baum.';
 
   /**
-   * Migration generator instance
+   * Migration generator instance.
    *
    * @var Baum\Generators\MigrationGenerator
    */
   protected $migrator;
 
   /**
-   * Model generator instance
+   * Model generator instance.
    *
    * @var Baum\Generators\ModelGenerator
    */
   protected $modeler;
 
   /**
-   * Create a new command instance
+   * Create a new command instance.
    *
    * @return void
    */
-  public function __construct(MigrationGenerator $migrator, ModelGenerator $modeler) {
+  public function __construct(MigrationGenerator $migrator, ModelGenerator $modeler)
+  {
       parent::__construct();
 
       $this->migrator = $migrator;
-      $this->modeler  = $modeler;
+      $this->modeler = $modeler;
   }
 
   /**
@@ -58,21 +60,23 @@ class InstallCommand extends Command {
    *
    * @return void
    */
-  public function fire() {
+  public function fire()
+  {
       $name = $this->input->getArgument('name');
       $this->writeMigration($name);
       $this->writeModel($name);
   }
 
   /**
-   * Get the command arguments
+   * Get the command arguments.
    *
    * @return array
    */
-  protected function getArguments() {
-      return array(
-        array('name', InputArgument::REQUIRED, 'Name to use for the scaffolding of the migration and model.')
-      );
+  protected function getArguments()
+  {
+      return [
+        ['name', InputArgument::REQUIRED, 'Name to use for the scaffolding of the migration and model.'],
+      ];
   }
 
   /**
@@ -81,7 +85,8 @@ class InstallCommand extends Command {
    * @param  string  $name
    * @return string
    */
-  protected function writeMigration($name) {
+  protected function writeMigration($name)
+  {
       $output = pathinfo($this->migrator->create($name, $this->getMigrationsPath()), PATHINFO_FILENAME);
       $this->line("      <fg=green;options=bold>create</fg=green;options=bold>  $output");
   }
@@ -92,7 +97,8 @@ class InstallCommand extends Command {
    * @param  string  $name
    * @return string
    */
-  protected function writeModel($name) {
+  protected function writeModel($name)
+  {
       $output = pathinfo($this->modeler->create($name, $this->getModelsPath()), PATHINFO_FILENAME);
       $this->line("      <fg=green;options=bold>create</fg=green;options=bold>  $output");
   }
@@ -102,7 +108,8 @@ class InstallCommand extends Command {
    *
    * @return string
    */
-  protected function getMigrationsPath() {
+  protected function getMigrationsPath()
+  {
       return $this->laravel->databasePath();
   }
 
@@ -111,8 +118,8 @@ class InstallCommand extends Command {
    *
    * @return string
    */
-  protected function getModelsPath() {
+  protected function getModelsPath()
+  {
       return $this->laravel->basePath();
   }
-
 }

--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -6,108 +6,108 @@ use Baum\Extensions\Eloquent\Collection;
 use Baum\Extensions\Eloquent\Model;
 
 /**
-* Node.
-*
-* This abstract class implements Nested Set functionality. A Nested Set is a
-* smart way to implement an ordered tree with the added benefit that you can
-* select all of their descendants with a single query. Drawbacks are that
-* insertion or move operations need more complex sql queries.
-*
-* Nested sets are appropiate when you want either an ordered tree (menus,
-* commercial categories, etc.) or an efficient way of querying big trees.
-*/
+ * Node.
+ *
+ * This abstract class implements Nested Set functionality. A Nested Set is a
+ * smart way to implement an ordered tree with the added benefit that you can
+ * select all of their descendants with a single query. Drawbacks are that
+ * insertion or move operations need more complex sql queries.
+ *
+ * Nested sets are appropiate when you want either an ordered tree (menus,
+ * commercial categories, etc.) or an efficient way of querying big trees.
+ */
 abstract class Node extends Model
 {
     /**
-    * Column name to store the reference to parent's node.
-    *
-    * @var string
-    */
+     * Column name to store the reference to parent's node.
+     *
+     * @var string
+     */
     protected $parentColumn = 'parent_id';
 
     /**
-    * Column name for left index.
-    *
-    * @var string
-    */
+     * Column name for left index.
+     *
+     * @var string
+     */
     protected $leftColumn = 'lft';
 
     /**
-    * Column name for right index.
-    *
-    * @var string
-    */
+     * Column name for right index.
+     *
+     * @var string
+     */
     protected $rightColumn = 'rgt';
 
     /**
-    * Column name for depth field.
-    *
-    * @var string
-    */
+     * Column name for depth field.
+     *
+     * @var string
+     */
     protected $depthColumn = 'depth';
 
     /**
-    * Column to perform the default sorting.
-    *
-    * @var string
-    */
+     * Column to perform the default sorting.
+     *
+     * @var string
+     */
     protected $orderColumn = null;
 
     /**
-    * Guard NestedSet fields from mass-assignment.
-    *
-    * @var array
-    */
+     * Guard NestedSet fields from mass-assignment.
+     *
+     * @var array
+     */
     protected $guarded = ['id', 'parent_id', 'lft', 'rgt', 'depth'];
 
     /**
-    * Indicates whether we should move to a new parent.
-    *
-    * @var int
-    */
+     * Indicates whether we should move to a new parent.
+     *
+     * @var int
+     */
     protected static $moveToNewParentId = null;
 
     /**
-    * Columns which restrict what we consider our Nested Set list.
-    *
-    * @var array
-    */
+     * Columns which restrict what we consider our Nested Set list.
+     *
+     * @var array
+     */
     protected $scoped = [];
 
     /**
-    * The "booting" method of the model.
-    *
-    * We'll use this method to register event listeners on a Node instance as
-    * suggested in the beta documentation...
-    *
-    * TODO:
-    *
-    *    - Find a way to avoid needing to declare the called methods "public"
-    *    as registering the event listeners *inside* this methods does not give
-    *    us an object context.
-    *
-    * Events:
-    *
-    *    1. "creating": Before creating a new Node we'll assign a default value
-    *    for the left and right indexes.
-    *
-    *    2. "saving": Before saving, we'll perform a check to see if we have to
-    *    move to another parent.
-    *
-    *    3. "saved": Move to the new parent after saving if needed and re-set
-    *    depth.
-    *
-    *    4. "deleting": Before delete we should prune all children and update
-    *    the left and right indexes for the remaining nodes.
-    *
-    *    5. (optional) "restoring": Before a soft-delete node restore operation,
-    *    shift its siblings.
-    *
-    *    6. (optional) "restore": After having restored a soft-deleted node,
-    *    restore all of its descendants.
-    *
-    * @return void
-    */
+     * The "booting" method of the model.
+     *
+     * We'll use this method to register event listeners on a Node instance as
+     * suggested in the beta documentation...
+     *
+     * TODO:
+     *
+     *    - Find a way to avoid needing to declare the called methods "public"
+     *    as registering the event listeners *inside* this methods does not give
+     *    us an object context.
+     *
+     * Events:
+     *
+     *    1. "creating": Before creating a new Node we'll assign a default value
+     *    for the left and right indexes.
+     *
+     *    2. "saving": Before saving, we'll perform a check to see if we have to
+     *    move to another parent.
+     *
+     *    3. "saved": Move to the new parent after saving if needed and re-set
+     *    depth.
+     *
+     *    4. "deleting": Before delete we should prune all children and update
+     *    the left and right indexes for the remaining nodes.
+     *
+     *    5. (optional) "restoring": Before a soft-delete node restore operation,
+     *    shift its siblings.
+     *
+     *    6. (optional) "restore": After having restored a soft-deleted node,
+     *    restore all of its descendants.
+     *
+     * @return void
+     */
     protected static function boot()
     {
         parent::boot();
@@ -141,173 +141,173 @@ abstract class Node extends Model
     }
 
     /**
-    * Get the parent column name.
-    *
-    * @return string
-    */
+     * Get the parent column name.
+     *
+     * @return string
+     */
     public function getParentColumnName()
     {
         return $this->parentColumn;
     }
 
     /**
-    * Get the table qualified parent column name.
-    *
-    * @return string
-    */
+     * Get the table qualified parent column name.
+     *
+     * @return string
+     */
     public function getQualifiedParentColumnName()
     {
         return $this->getTable().'.'.$this->getParentColumnName();
     }
 
     /**
-    * Get the value of the models "parent_id" field.
-    *
-    * @return int
-    */
+     * Get the value of the models "parent_id" field.
+     *
+     * @return int
+     */
     public function getParentId()
     {
         return $this->getAttribute($this->getparentColumnName());
     }
 
     /**
-    * Get the "left" field column name.
-    *
-    * @return string
-    */
+     * Get the "left" field column name.
+     *
+     * @return string
+     */
     public function getLeftColumnName()
     {
         return $this->leftColumn;
     }
 
     /**
-    * Get the table qualified "left" field column name.
-    *
-    * @return string
-    */
+     * Get the table qualified "left" field column name.
+     *
+     * @return string
+     */
     public function getQualifiedLeftColumnName()
     {
         return $this->getTable().'.'.$this->getLeftColumnName();
     }
 
     /**
-    * Get the value of the model's "left" field.
-    *
-    * @return int
-    */
+     * Get the value of the model's "left" field.
+     *
+     * @return int
+     */
     public function getLeft()
     {
         return $this->getAttribute($this->getLeftColumnName());
     }
 
     /**
-    * Get the "right" field column name.
-    *
-    * @return string
-    */
+     * Get the "right" field column name.
+     *
+     * @return string
+     */
     public function getRightColumnName()
     {
         return $this->rightColumn;
     }
 
     /**
-    * Get the table qualified "right" field column name.
-    *
-    * @return string
-    */
+     * Get the table qualified "right" field column name.
+     *
+     * @return string
+     */
     public function getQualifiedRightColumnName()
     {
         return $this->getTable().'.'.$this->getRightColumnName();
     }
 
     /**
-    * Get the value of the model's "right" field.
-    *
-    * @return int
-    */
+     * Get the value of the model's "right" field.
+     *
+     * @return int
+     */
     public function getRight()
     {
         return $this->getAttribute($this->getRightColumnName());
     }
 
     /**
-    * Get the "depth" field column name.
-    *
-    * @return string
-    */
+     * Get the "depth" field column name.
+     *
+     * @return string
+     */
     public function getDepthColumnName()
     {
         return $this->depthColumn;
     }
 
     /**
-    * Get the table qualified "depth" field column name.
-    *
-    * @return string
-    */
+     * Get the table qualified "depth" field column name.
+     *
+     * @return string
+     */
     public function getQualifiedDepthColumnName()
     {
         return $this->getTable().'.'.$this->getDepthColumnName();
     }
 
     /**
-    * Get the model's "depth" value.
-    *
-    * @return int
-    */
+     * Get the model's "depth" value.
+     *
+     * @return int
+     */
     public function getDepth()
     {
         return $this->getAttribute($this->getDepthColumnName());
     }
 
     /**
-    * Get the "order" field column name.
-    *
-    * @return string
-    */
+     * Get the "order" field column name.
+     *
+     * @return string
+     */
     public function getOrderColumnName()
     {
         return is_null($this->orderColumn) ? $this->getLeftColumnName() : $this->orderColumn;
     }
 
     /**
-    * Get the table qualified "order" field column name.
-    *
-    * @return string
-    */
+     * Get the table qualified "order" field column name.
+     *
+     * @return string
+     */
     public function getQualifiedOrderColumnName()
     {
         return $this->getTable().'.'.$this->getOrderColumnName();
     }
 
     /**
-    * Get the model's "order" value.
-    *
-    * @return mixed
-    */
+     * Get the model's "order" value.
+     *
+     * @return mixed
+     */
     public function getOrder()
     {
         return $this->getAttribute($this->getOrderColumnName());
     }
 
     /**
-    * Get the column names which define our scope.
-    *
-    * @return array
-    */
+     * Get the column names which define our scope.
+     *
+     * @return array
+     */
     public function getScopedColumns()
     {
-        return (array)$this->scoped;
+        return (array) $this->scoped;
     }
 
     /**
-    * Get the qualified column names which define our scope.
-    *
-    * @return array
-    */
+     * Get the qualified column names which define our scope.
+     *
+     * @return array
+     */
     public function getQualifiedScopedColumns()
     {
-        if (!$this->isScoped()) {
+        if (! $this->isScoped()) {
             return $this->getScopedColumns();
         }
 
@@ -318,31 +318,31 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns wether this particular node instance is scoped by certain fields
-    * or not.
-    *
-    * @return bool
-    */
+     * Returns wether this particular node instance is scoped by certain fields
+     * or not.
+     *
+     * @return bool
+     */
     public function isScoped()
     {
-        return !!(count($this->getScopedColumns()) > 0);
+        return ! ! (count($this->getScopedColumns()) > 0);
     }
 
     /**
-    * Parent relation (self-referential) 1-1.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-    */
+     * Parent relation (self-referential) 1-1.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function parent()
     {
         return $this->belongsTo(get_class($this), $this->getParentColumnName());
     }
 
     /**
-    * Children relation (self-referential) 1-N.
-    *
-    * @return \Illuminate\Database\Eloquent\Relations\HasMany
-    */
+     * Children relation (self-referential) 1-N.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function children()
     {
         return $this->hasMany(get_class($this), $this->getParentColumnName())
@@ -350,10 +350,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Get a new "scoped" query builder for the Node's model.
-    *
-    * @return \Illuminate\Database\Eloquent\Builder|static
-    */
+     * Get a new "scoped" query builder for the Node's model.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder|static
+     */
     public function newNestedSetQuery()
     {
         $builder = $this->newQuery()->orderBy($this->getQualifiedOrderColumnName());
@@ -368,22 +368,22 @@ abstract class Node extends Model
     }
 
     /**
-    * Overload new Collection.
-    *
-    * @param array $models
-    * @return \Baum\Extensions\Eloquent\Collection
-    */
+     * Overload new Collection.
+     *
+     * @param array $models
+     * @return \Baum\Extensions\Eloquent\Collection
+     */
     public function newCollection(array $models = [])
     {
         return new Collection($models);
     }
 
     /**
-    * Get all of the nodes from the database.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection|static[]
-    */
+     * Get all of the nodes from the database.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection|static[]
+     */
     public static function all($columns = ['*'])
     {
         $instance = new static;
@@ -394,20 +394,20 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns the first root node.
-    *
-    * @return NestedSet
-    */
+     * Returns the first root node.
+     *
+     * @return NestedSet
+     */
     public static function root()
     {
         return static::roots()->first();
     }
 
     /**
-    * Static query scope. Returns a query scope with all root nodes.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Static query scope. Returns a query scope with all root nodes.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public static function roots()
     {
         $instance = new static;
@@ -418,11 +418,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Static query scope. Returns a query scope with all nodes which are at
-    * the end of a branch.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Static query scope. Returns a query scope with all nodes which are at
+     * the end of a branch.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public static function allLeaves()
     {
         $instance = new static;
@@ -438,11 +438,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Static query scope. Returns a query scope with all nodes which are at
-    * the middle of a branch (not root and not leaves).
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Static query scope. Returns a query scope with all nodes which are at
+     * the middle of a branch (not root and not leaves).
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public static function allTrunks()
     {
         $instance = new static;
@@ -459,21 +459,22 @@ abstract class Node extends Model
     }
 
     /**
-    * Checks wether the underlying Nested Set structure is valid.
-    *
-    * @return bool
-    */
+     * Checks wether the underlying Nested Set structure is valid.
+     *
+     * @return bool
+     */
     public static function isValidNestedSet()
     {
         $validator = new SetValidator(new static);
+
         return $validator->passes();
     }
 
     /**
-    * Rebuilds the structure of the current Nested Set.
-    *
-    * @return void
-    */
+     * Rebuilds the structure of the current Nested Set.
+     *
+     * @return void
+     */
     public static function rebuild()
     {
         $builder = new SetBuilder(new static);
@@ -481,55 +482,55 @@ abstract class Node extends Model
     }
 
     /**
-    * Maps the provided tree structure into the database.
-    *
-    * @param   array|\Illuminate\Support\Contracts\ArrayableInterface
-    * @return  bool
-    */
+     * Maps the provided tree structure into the database.
+     *
+     * @param   array|\Illuminate\Support\Contracts\ArrayableInterface
+     * @return  bool
+     */
     public static function buildTree($nodeList)
     {
         return with(new static)->makeTree($nodeList);
     }
 
     /**
-    * Query scope which extracts a certain node object from the current query
-    * expression.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Query scope which extracts a certain node object from the current query
+     * expression.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function scopeWithoutNode($query, $node)
     {
         return $query->where($node->getKeyName(), '!=', $node->getKey());
     }
 
     /**
-    * Extracts current node (self) from current query expression.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Extracts current node (self) from current query expression.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function scopeWithoutSelf($query)
     {
         return $this->scopeWithoutNode($query, $this);
     }
 
     /**
-    * Extracts first root (from the current node p-o-v) from current query
-    * expression.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Extracts first root (from the current node p-o-v) from current query
+     * expression.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function scopeWithoutRoot($query)
     {
         return $this->scopeWithoutNode($query, $this->getRoot());
     }
 
     /**
-    * Provides a depth level limit for the query.
-    *
-    * @param   query   \Illuminate\Database\Query\Builder
-    * @param   limit   integer
-    * @return  \Illuminate\Database\Query\Builder
-    */
+     * Provides a depth level limit for the query.
+     *
+     * @param   query   \Illuminate\Database\Query\Builder
+     * @param   limit   integer
+     * @return  \Illuminate\Database\Query\Builder
+     */
     public function scopeLimitDepth($query, $limit)
     {
         $depth = $this->exists ? $this->getDepth() : $this->getLevel();
@@ -540,50 +541,50 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns true if this is a root node.
-    *
-    * @return bool
-    */
+     * Returns true if this is a root node.
+     *
+     * @return bool
+     */
     public function isRoot()
     {
         return is_null($this->getParentId());
     }
 
     /**
-    * Returns true if this is a leaf node (end of a branch).
-    *
-    * @return bool
-    */
+     * Returns true if this is a leaf node (end of a branch).
+     *
+     * @return bool
+     */
     public function isLeaf()
     {
         return $this->exists && ($this->getRight() - $this->getLeft() == 1);
     }
 
     /**
-    * Returns true if this is a trunk node (not root or leaf).
-    *
-    * @return bool
-    */
+     * Returns true if this is a trunk node (not root or leaf).
+     *
+     * @return bool
+     */
     public function isTrunk()
     {
-        return !$this->isRoot() && !$this->isLeaf();
+        return ! $this->isRoot() && ! $this->isLeaf();
     }
 
     /**
-    * Returns true if this is a child node.
-    *
-    * @return bool
-    */
+     * Returns true if this is a child node.
+     *
+     * @return bool
+     */
     public function isChild()
     {
-        return !$this->isRoot();
+        return ! $this->isRoot();
     }
 
     /**
-    * Returns the root node starting at the current node.
-    *
-    * @return NestedSet
-    */
+     * Returns the root node starting at the current node.
+     *
+     * @return NestedSet
+     */
     public function getRoot()
     {
         if ($this->exists) {
@@ -591,7 +592,7 @@ abstract class Node extends Model
         } else {
             $parentId = $this->getParentId();
 
-            if (!is_null($parentId) && $currentParent = static::find($parentId)) {
+            if (! is_null($parentId) && $currentParent = static::find($parentId)) {
                 return $currentParent->getRoot();
             } else {
                 return $this;
@@ -600,11 +601,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Instance scope which targes all the ancestor chain nodes including
-    * the current one.
-    *
-    * @return \Illuminate\Database\Eloquent\Builder
-    */
+     * Instance scope which targes all the ancestor chain nodes including
+     * the current one.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function ancestorsAndSelf()
     {
         return $this->newNestedSetQuery()
@@ -613,67 +614,67 @@ abstract class Node extends Model
     }
 
     /**
-    * Get all the ancestor chain from the database including the current node.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Get all the ancestor chain from the database including the current node.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getAncestorsAndSelf($columns = ['*'])
     {
         return $this->ancestorsAndSelf()->get($columns);
     }
 
     /**
-    * Get all the ancestor chain from the database including the current node
-    * but without the root node.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Get all the ancestor chain from the database including the current node
+     * but without the root node.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getAncestorsAndSelfWithoutRoot($columns = ['*'])
     {
         return $this->ancestorsAndSelf()->withoutRoot()->get($columns);
     }
 
     /**
-    * Instance scope which targets all the ancestor chain nodes excluding
-    * the current one.
-    *
-    * @return \Illuminate\Database\Eloquent\Builder
-    */
+     * Instance scope which targets all the ancestor chain nodes excluding
+     * the current one.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function ancestors()
     {
         return $this->ancestorsAndSelf()->withoutSelf();
     }
 
     /**
-    * Get all the ancestor chain from the database excluding the current node.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Get all the ancestor chain from the database excluding the current node.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getAncestors($columns = ['*'])
     {
         return $this->ancestors()->get($columns);
     }
 
     /**
-    * Get all the ancestor chain from the database excluding the current node
-    * and the root node (from the current node's perspective).
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Get all the ancestor chain from the database excluding the current node
+     * and the root node (from the current node's perspective).
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getAncestorsWithoutRoot($columns = ['*'])
     {
         return $this->ancestors()->withoutRoot()->get($columns);
     }
 
     /**
-    * Instance scope which targets all children of the parent, including self.
-    *
-    * @return \Illuminate\Database\Eloquent\Builder
-    */
+     * Instance scope which targets all children of the parent, including self.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function siblingsAndSelf()
     {
         return $this->newNestedSetQuery()
@@ -681,43 +682,43 @@ abstract class Node extends Model
     }
 
     /**
-    * Get all children of the parent, including self.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Get all children of the parent, including self.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getSiblingsAndSelf($columns = ['*'])
     {
         return $this->siblingsAndSelf()->get($columns);
     }
 
     /**
-    * Instance scope targeting all children of the parent, except self.
-    *
-    * @return \Illuminate\Database\Eloquent\Builder
-    */
+     * Instance scope targeting all children of the parent, except self.
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
     public function siblings()
     {
         return $this->siblingsAndSelf()->withoutSelf();
     }
 
     /**
-    * Return all children of the parent, except self.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Return all children of the parent, except self.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getSiblings($columns = ['*'])
     {
         return $this->siblings()->get($columns);
     }
 
     /**
-    * Instance scope targeting all of its nested children which do not have
-    * children.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Instance scope targeting all of its nested children which do not have
+     * children.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function leaves()
     {
         $grammar = $this->getConnection()->getQueryGrammar();
@@ -730,22 +731,22 @@ abstract class Node extends Model
     }
 
     /**
-    * Return all of its nested children which do not have children.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Return all of its nested children which do not have children.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getLeaves($columns = ['*'])
     {
         return $this->leaves()->get($columns);
     }
 
     /**
-    * Instance scope targeting all of its nested children which are between the
-    * root and the leaf nodes (middle branch).
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Instance scope targeting all of its nested children which are between the
+     * root and the leaf nodes (middle branch).
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function trunks()
     {
         $grammar = $this->getConnection()->getQueryGrammar();
@@ -759,21 +760,21 @@ abstract class Node extends Model
     }
 
     /**
-    * Return all of its nested children which are trunks.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Return all of its nested children which are trunks.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getTrunks($columns = ['*'])
     {
         return $this->trunks()->get($columns);
     }
 
     /**
-    * Scope targeting itself and all of its nested children.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Scope targeting itself and all of its nested children.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function descendantsAndSelf()
     {
         return $this->newNestedSetQuery()
@@ -782,11 +783,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Retrieve all nested children an self.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Retrieve all nested children an self.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getDescendantsAndSelf($columns = ['*'])
     {
         if (is_array($columns)) {
@@ -801,10 +802,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Retrieve all other nodes at the same depth,
-    *
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Retrieve all other nodes at the same depth,.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getOthersAtSameDepth()
     {
         return $this->newNestedSetQuery()
@@ -813,21 +814,21 @@ abstract class Node extends Model
     }
 
     /**
-    * Set of all children & nested children.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Set of all children & nested children.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function descendants()
     {
         return $this->descendantsAndSelf()->withoutSelf();
     }
 
     /**
-    * Retrieve all of its children & nested children.
-    *
-    * @param  array  $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Retrieve all of its children & nested children.
+     *
+     * @param  array  $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getDescendants($columns = ['*'])
     {
         if (is_array($columns)) {
@@ -843,32 +844,32 @@ abstract class Node extends Model
     }
 
     /**
-    * Set of "immediate" descendants (aka children), alias for the children relation.
-    *
-    * @return \Illuminate\Database\Query\Builder
-    */
+     * Set of "immediate" descendants (aka children), alias for the children relation.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
     public function immediateDescendants()
     {
         return $this->children();
     }
 
     /**
-    * Retrive all of its "immediate" descendants.
-    *
-    * @param array   $columns
-    * @return \Illuminate\Database\Eloquent\Collection
-    */
+     * Retrive all of its "immediate" descendants.
+     *
+     * @param array   $columns
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
     public function getImmediateDescendants($columns = ['*'])
     {
         return $this->children()->get($columns);
     }
 
     /**
-    * Returns the level of this node in the tree.
-    * Root level is 0.
-    *
-    * @return int
-    */
+     * Returns the level of this node in the tree.
+     * Root level is 0.
+     *
+     * @return int
+     */
     public function getLevel()
     {
         if (is_null($this->getParentId())) {
@@ -879,11 +880,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns true if node is a descendant.
-    *
-    * @param NestedSet
-    * @return bool
-    */
+     * Returns true if node is a descendant.
+     *
+     * @param NestedSet
+     * @return bool
+     */
     public function isDescendantOf($other)
     {
         return (
@@ -894,11 +895,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns true if node is self or a descendant.
-    *
-    * @param NestedSet
-    * @return bool
-    */
+     * Returns true if node is self or a descendant.
+     *
+     * @param NestedSet
+     * @return bool
+     */
     public function isSelfOrDescendantOf($other)
     {
         return (
@@ -909,11 +910,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns true if node is an ancestor.
-    *
-    * @param NestedSet
-    * @return bool
-    */
+     * Returns true if node is an ancestor.
+     *
+     * @param NestedSet
+     * @return bool
+     */
     public function isAncestorOf($other)
     {
         return (
@@ -924,11 +925,11 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns true if node is self or an ancestor.
-    *
-    * @param NestedSet
-    * @return bool
-    */
+     * Returns true if node is self or an ancestor.
+     *
+     * @param NestedSet
+     * @return bool
+     */
     public function isSelfOrAncestorOf($other)
     {
         return (
@@ -939,10 +940,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns the first sibling to the left.
-    *
-    * @return NestedSet
-    */
+     * Returns the first sibling to the left.
+     *
+     * @return NestedSet
+     */
     public function getLeftSibling()
     {
         return $this->siblings()
@@ -953,10 +954,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Returns the first sibling to the right.
-    *
-    * @return NestedSet
-    */
+     * Returns the first sibling to the right.
+     *
+     * @return NestedSet
+     */
     public function getRightSibling()
     {
         return $this->siblings()
@@ -965,136 +966,136 @@ abstract class Node extends Model
     }
 
     /**
-    * Find the left sibling and move to left of it.
-    *
-    * @return \Baum\Node
-    */
+     * Find the left sibling and move to left of it.
+     *
+     * @return \Baum\Node
+     */
     public function moveLeft()
     {
         return $this->moveToLeftOf($this->getLeftSibling());
     }
 
     /**
-    * Find the right sibling and move to the right of it.
-    *
-    * @return \Baum\Node
-    */
+     * Find the right sibling and move to the right of it.
+     *
+     * @return \Baum\Node
+     */
     public function moveRight()
     {
         return $this->moveToRightOf($this->getRightSibling());
     }
 
     /**
-    * Move to the node to the left of ...
-    *
-    * @return \Baum\Node
-    */
+     * Move to the node to the left of ...
+     *
+     * @return \Baum\Node
+     */
     public function moveToLeftOf($node)
     {
         return $this->moveTo($node, 'left');
     }
 
     /**
-    * Move to the node to the right of ...
-    *
-    * @return \Baum\Node
-    */
+     * Move to the node to the right of ...
+     *
+     * @return \Baum\Node
+     */
     public function moveToRightOf($node)
     {
         return $this->moveTo($node, 'right');
     }
 
     /**
-    * Alias for moveToRightOf.
-    *
-    * @return \Baum\Node
-    */
+     * Alias for moveToRightOf.
+     *
+     * @return \Baum\Node
+     */
     public function makeNextSiblingOf($node)
     {
         return $this->moveToRightOf($node);
     }
 
     /**
-    * Alias for moveToRightOf.
-    *
-    * @return \Baum\Node
-    */
+     * Alias for moveToRightOf.
+     *
+     * @return \Baum\Node
+     */
     public function makeSiblingOf($node)
     {
         return $this->moveToRightOf($node);
     }
 
     /**
-    * Alias for moveToLeftOf.
-    *
-    * @return \Baum\Node
-    */
+     * Alias for moveToLeftOf.
+     *
+     * @return \Baum\Node
+     */
     public function makePreviousSiblingOf($node)
     {
         return $this->moveToLeftOf($node);
     }
 
     /**
-    * Make the node a child of ...
-    *
-    * @return \Baum\Node
-    */
+     * Make the node a child of ...
+     *
+     * @return \Baum\Node
+     */
     public function makeChildOf($node)
     {
         return $this->moveTo($node, 'child');
     }
 
     /**
-    * Make the node the first child of ...
-    *
-    * @return \Baum\Node
-    */
+     * Make the node the first child of ...
+     *
+     * @return \Baum\Node
+     */
     public function makeFirstChildOf($node)
     {
         if ($node->children()->count() == 0) {
-           return $this->makeChildOf($node);
+            return $this->makeChildOf($node);
         }
 
         return $this->moveToLeftOf($node->children()->first());
     }
 
     /**
-    * Make the node the last child of ...
-    *
-    * @return \Baum\Node
-    */
+     * Make the node the last child of ...
+     *
+     * @return \Baum\Node
+     */
     public function makeLastChildOf($node)
     {
         return $this->makeChildOf($node);
     }
 
     /**
-    * Make current node a root node.
-    *
-    * @return \Baum\Node
-    */
+     * Make current node a root node.
+     *
+     * @return \Baum\Node
+     */
     public function makeRoot()
     {
         return $this->moveTo($this, 'root');
     }
 
     /**
-    * Equals?
-    *
-    * @param \Baum\Node
-    * @return bool
-    */
+     * Equals?
+     *
+     * @param \Baum\Node
+     * @return bool
+     */
     public function equals($node)
     {
         return ($this == $node);
     }
 
     /**
-    * Checkes if the given node is in the same scope as the current one.
-    *
-    * @param \Baum\Node
-    * @return bool
-    */
+     * Checkes if the given node is in the same scope as the current one.
+     *
+     * @param \Baum\Node
+     * @return bool
+     */
     public function inSameScope($other)
     {
         foreach ($this->getScopedColumns() as $fld) {
@@ -1107,12 +1108,12 @@ abstract class Node extends Model
     }
 
     /**
-    * Checks wether the given node is a descendant of itself. Basically, whether
-    * its in the subtree defined by the left and right indices.
-    *
-    * @param \Baum\Node
-    * @return bool
-    */
+     * Checks wether the given node is a descendant of itself. Basically, whether
+     * its in the subtree defined by the left and right indices.
+     *
+     * @param \Baum\Node
+     * @return bool
+     */
     public function insideSubtree($node)
     {
         return (
@@ -1124,10 +1125,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Sets default values for left and right fields.
-    *
-    * @return void
-    */
+     * Sets default values for left and right fields.
+     *
+     * @return void
+     */
     public function setDefaultLeftAndRight()
     {
         $withHighestRight = $this->newNestedSetQuery()->reOrderBy($this->getRightColumnName(), 'desc')->take(1)->sharedLock()->first();
@@ -1142,14 +1143,14 @@ abstract class Node extends Model
     }
 
     /**
-    * Store the parent_id if the attribute is modified so as we are able to move
-    * the node to this new parent after saving.
-    *
-    * @return void
-    */
+     * Store the parent_id if the attribute is modified so as we are able to move
+     * the node to this new parent after saving.
+     *
+     * @return void
+     */
     public function storeNewParent()
     {
-        if ($this->isDirty($this->getParentColumnName()) && ($this->exists || !$this->isRoot())) {
+        if ($this->isDirty($this->getParentColumnName()) && ($this->exists || ! $this->isRoot())) {
             static::$moveToNewParentId = $this->getParentId();
         } else {
             static::$moveToNewParentId = false;
@@ -1157,50 +1158,50 @@ abstract class Node extends Model
     }
 
     /**
-    * Move to the new parent if appropiate.
-    *
-    * @return void
-    */
+     * Move to the new parent if appropiate.
+     *
+     * @return void
+     */
     public function moveToNewParent()
     {
         $pid = static::$moveToNewParentId;
 
         if (is_null($pid)) {
-           $this->makeRoot();
+            $this->makeRoot();
         } elseif ($pid !== false) {
             $this->makeChildOf($pid);
         }
     }
 
     /**
-    * Sets the depth attribute.
-    *
-    * @return \Baum\Node
-    */
+     * Sets the depth attribute.
+     *
+     * @return \Baum\Node
+     */
     public function setDepth()
     {
-      $self = $this;
+        $self = $this;
 
-      $this->getConnection()->transaction(function () use ($self) {
+        $this->getConnection()->transaction(function () use ($self) {
           $self->reload();
           $level = $self->getLevel();
           $self->newNestedSetQuery()->where($self->getKeyName(), '=', $self->getKey())->update([$self->getDepthColumnName() => $level]);
           $self->setAttribute($self->getDepthColumnName(), $level);
       });
 
-      return $this;
+        return $this;
     }
 
     /**
-    * Sets the depth attribute for the current node and all of its descendants.
-    *
-    * @return \Baum\Node
-    */
+     * Sets the depth attribute for the current node and all of its descendants.
+     *
+     * @return \Baum\Node
+     */
     public function setDepthWithSubtree()
     {
-      $self = $this;
+        $self = $this;
 
-      $this->getConnection()->transaction(function () use ($self) {
+        $this->getConnection()->transaction(function () use ($self) {
           $self->reload();
 
           $self->descendantsAndSelf()->select($self->getKeyName())->lockForUpdate()->get();
@@ -1212,20 +1213,20 @@ abstract class Node extends Model
           $self->setAttribute($self->getDepthColumnName(), $newDepth);
 
           $diff = $newDepth - $oldDepth;
-          if (!$self->isLeaf() && $diff != 0) {
+          if (! $self->isLeaf() && $diff != 0) {
               $self->descendants()->increment($self->getDepthColumnName(), $diff);
           }
       });
 
-      return $this;
+        return $this;
     }
 
     /**
-    * Prunes a branch off the tree, shifting all the elements on the right
-    * back to the left so the counts work.
-    *
-    * @return void;
-    */
+     * Prunes a branch off the tree, shifting all the elements on the right
+     * back to the left so the counts work.
+     *
+     * @return void;
+     */
     public function destroyDescendants()
     {
         if (is_null($this->getRight()) || is_null($this->getLeft())) {
@@ -1257,10 +1258,10 @@ abstract class Node extends Model
     }
 
     /**
-    * "Makes room" for the the current node between its siblings.
-    *
-    * @return void
-    */
+     * "Makes room" for the the current node between its siblings.
+     *
+     * @return void
+     */
     public function shiftSiblingsForRestore()
     {
         if (is_null($this->getRight()) || is_null($this->getLeft())) {
@@ -1283,10 +1284,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Restores all of the current node's descendants.
-    *
-    * @return void
-    */
+     * Restores all of the current node's descendants.
+     *
+     * @return void
+     */
     public function restoreDescendants()
     {
         if (is_null($this->getRight()) || is_null($this->getLeft())) {
@@ -1308,10 +1309,10 @@ abstract class Node extends Model
     }
 
     /**
-    * Return an key-value array indicating the node's depth with $seperator.
-    *
-    * @return Array
-    */
+     * Return an key-value array indicating the node's depth with $seperator.
+     *
+     * @return Array
+     */
     public static function getNestedList($column, $key = null, $seperator = ' ')
     {
         $instance = new static;
@@ -1323,45 +1324,46 @@ abstract class Node extends Model
 
         return array_combine(array_map(function ($node) use ($key) {
             return $node[$key];
-        }, $nodes), array_map(function ($node) use ($seperator, $depthColumn,$column) {
+        }, $nodes), array_map(function ($node) use ($seperator, $depthColumn, $column) {
             return str_repeat($seperator, $node[$depthColumn]).$node[$column];
         }, $nodes));
     }
 
     /**
-    * Maps the provided tree structure into the database using the current node
-    * as the parent. The provided tree structure will be inserted/updated as the
-    * descendancy subtree of the current node instance.
-    *
-    * @param   array|\Illuminate\Support\Contracts\ArrayableInterface
-    * @return  bool
-    */
+     * Maps the provided tree structure into the database using the current node
+     * as the parent. The provided tree structure will be inserted/updated as the
+     * descendancy subtree of the current node instance.
+     *
+     * @param   array|\Illuminate\Support\Contracts\ArrayableInterface
+     * @return  bool
+     */
     public function makeTree($nodeList)
     {
         $mapper = new SetMapper($this);
+
         return $mapper->map($nodeList);
     }
 
     /**
-    * Main move method. Here we handle all node movements with the corresponding
-    * lft/rgt index updates.
-    *
-    * @param Baum\Node|int $target
-    * @param string        $position
-    * @return \Baum\Node
-    */
+     * Main move method. Here we handle all node movements with the corresponding
+     * lft/rgt index updates.
+     *
+     * @param Baum\Node|int $target
+     * @param string        $position
+     * @return \Baum\Node
+     */
     protected function moveTo($target, $position)
     {
         return Move::to($this, $target, $position);
     }
 
     /**
-    * Compute current node level. If could not move past ourseleves return
-    * our ancestor count, otherwhise get the first parent level + the computed
-    * nesting.
-    *
-    * @return int
-    */
+     * Compute current node level. If could not move past ourseleves return
+     * our ancestor count, otherwhise get the first parent level + the computed
+     * nesting.
+     *
+     * @return int
+     */
     protected function computeLevel()
     {
         list($node, $nesting) = $this->determineDepth($this);
@@ -1374,12 +1376,12 @@ abstract class Node extends Model
     }
 
     /**
-    * Return an array with the last node we could reach and its nesting level.
-    *
-    * @param   Baum\Node $node
-    * @param   int   $nesting
-    * @return  array
-    */
+     * Return an array with the last node we could reach and its nesting level.
+     *
+     * @param   Baum\Node $node
+     * @param   int   $nesting
+     * @return  array
+     */
     protected function determineDepth($node, $nesting = 0)
     {
         // Traverse back up the ancestry chain and add to the nesting level count

--- a/src/Baum/SetMapper.php
+++ b/src/Baum/SetMapper.php
@@ -8,10 +8,10 @@ use Illuminate\Support\Contracts\ArrayableInterface;
 class SetMapper
 {
     /**
-    * Node instance for reference.
-    *
-    * @var \Baum\Node
-    */
+     * Node instance for reference.
+     *
+     * @var \Baum\Node
+     */
     protected $node = null;
 
     /**
@@ -116,7 +116,7 @@ class SetMapper
                 return false;
             }
 
-            if (!$node->isRoot()) {
+            if (! $node->isRoot()) {
                 $node->makeLastChildOf($node->parent);
             }
 
@@ -128,7 +128,7 @@ class SetMapper
                 if (count($children) > 0) {
                     $result = $this->mapTreeRecursive($children, $node->getKey(), $affectedKeys);
 
-                    if (!$result) {
+                    if (! $result) {
                         return false;
                     }
                 }
@@ -141,12 +141,14 @@ class SetMapper
     protected function getSearchAttributes($attributes)
     {
         $searchable = [$this->node->getKeyName()];
+
         return array_only($attributes, $searchable);
     }
 
     protected function getDataAttributes($attributes)
     {
         $exceptions = [$this->node->getKeyName(), $this->getChildrenKeyName()];
+
         return array_except($attributes, $exceptions);
     }
 

--- a/tests/suite/Category/CategoryColumnsTest.php
+++ b/tests/suite/Category/CategoryColumnsTest.php
@@ -150,10 +150,10 @@ class CategoryColumnsTest extends CategoryTestCase
     {
         $this->assertEquals(1, $this->categories('Root 1')->getOthersAtSameDepth()->count());
         $this->assertEquals('Root 2', $this->categories('Root 1')->getOthersAtSameDepth()->first()->name);
-        
+
         $this->assertEquals(2, $this->categories('Child 1')->getOthersAtSameDepth()->count());
         $this->assertEquals(0, $this->categories('Child 2.1')->getOthersAtSameDepth()->count());
-        
+
         $this->assertEquals('Child 2', $this->categories('Child 1')->getOthersAtSameDepth()->get()[0]->name);
         $this->assertEquals('Child 3', $this->categories('Child 1')->getOthersAtSameDepth()->get()[1]->name);
     }

--- a/tests/suite/Category/CategoryTreeMapperTest.php
+++ b/tests/suite/Category/CategoryTreeMapperTest.php
@@ -343,7 +343,6 @@ class CategoryTreeMapperTest extends BaumTestCase
             ['id' => 14, 'name' => 'Child 2.4'],
         ];
 
-
         $hierarchy = $parent->reload()->getDescendants()->toHierarchy()->toArray();
         $this->assertArraysAreEqual($expected, array_ints_keys(hmap($hierarchy, ['id', 'name'])));
     }


### PR DESCRIPTION
This fixes the build issues which are being triggered by style ci failing. It seems as though the original codebase is mostly not psr-2 compliant because it uses two spaces for indentation. The fixer doesn't seem to have actually fixed this anywhere, but in some places has messed up docblock indentation, I guess because it assumes that the indentation is four spaces.