### PR TITLE
Specify parent for nested list query

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -1308,11 +1308,18 @@ abstract class Node extends Model
     }
 
     /**
-    * Return an key-value array indicating the node's depth with $seperator.
+    * Return an key-value array indicating the node's depth with $separator.
     *
-    * @return Array
+    * By specifying a $parent Node, the list is limited to $parent and its children.
+    *
+    * @param string $column The attribute which is used to populate values of the array.
+    * @param null $key The attribute which is used to populate keys of the array.
+    * @param string $separator A separator which is prepended to values, according to their depth.
+    * @param Node|null $parent The parent node to use.
+    * @param bool|true $sep_relative Whether the separator length should be relative to the $parent depth or absolute.
+    * @return array
     */
-    public static function getNestedList($column, $key = null, $seperator = ' ')
+    public static function getNestedList($column, $key = null, $separator = ' ', Node $parent = null, $sep_relative = true)
     {
         $instance = new static;
 
@@ -1321,10 +1328,20 @@ abstract class Node extends Model
 
         $nodes = $instance->newNestedSetQuery()->get()->toArray();
 
+        $initialDepth = 0;
+        if ($parent) {
+            $nodes = $parent->getDescendantsAndSelf()->toArray();
+            if ($sep_relative) {
+                $initialDepth = $parent[$depthColumn];
+            }
+        } else {
+            $nodes = $instance->newNestedSetQuery()->get()->toArray();
+        }
+
         return array_combine(array_map(function ($node) use ($key) {
             return $node[$key];
-        }, $nodes), array_map(function ($node) use ($seperator, $depthColumn,$column) {
-            return str_repeat($seperator, $node[$depthColumn]).$node[$column];
+        }, $nodes), array_map(function ($node) use ($separator, $depthColumn, $column, $initialDepth) {
+            return str_repeat($separator, $node[$depthColumn] - $initialDepth).$node[$column];
         }, $nodes));
     }
 

--- a/tests/suite/Category/CategoryHierarchyTest.php
+++ b/tests/suite/Category/CategoryHierarchyTest.php
@@ -755,14 +755,34 @@ class CategoryHierarchyTest extends CategoryTestCase
         $nestedList = Category::getNestedList('name', 'id', $seperator);
 
         $expected = [
-      1 => str_repeat($seperator, 0).'Root 1',
-      2 => str_repeat($seperator, 1).'Child 1',
-      3 => str_repeat($seperator, 1).'Child 2',
-      4 => str_repeat($seperator, 2).'Child 2.1',
-      5 => str_repeat($seperator, 1).'Child 3',
-      6 => str_repeat($seperator, 0).'Root 2',
-    ];
+          1 => str_repeat($seperator, 0).'Root 1',
+          2 => str_repeat($seperator, 1).'Child 1',
+          3 => str_repeat($seperator, 1).'Child 2',
+          4 => str_repeat($seperator, 2).'Child 2.1',
+          5 => str_repeat($seperator, 1).'Child 3',
+          6 => str_repeat($seperator, 0).'Root 2',
+        ];
 
         $this->assertArraysAreEqual($expected, $nestedList);
     }
+
+    public function testGetNestedListWithParent() {
+        $separator = ' ';
+        $parent = Category::find(2);
+        $nestedList = Category::getNestedList('name', 'id', $separator, $parent);
+
+        $expected = array(
+            2 => str_repeat($separator, 0). 'Child 1',
+        );
+        $this->assertArraysAreEqual($expected, $nestedList);
+
+        $nestedList = Category::getNestedList('name', 'id', $separator, $parent, false);
+
+        $expected = array(
+            2 => str_repeat($separator, 1). 'Child 1',
+        );
+
+        $this->assertArraysAreEqual($expected, $nestedList);
+    }
+
 }


### PR DESCRIPTION
This allows a nested list query to be based of of a parent within the tree other than the root node(s).
