### PR TITLE
Buildtree reorder fix + allow laravel 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "illuminate/console": "5.2.*",
-    "illuminate/database": "5.2.*@dev",
-    "illuminate/events": "5.2.*",
-    "illuminate/filesystem": "5.2.*",
-    "illuminate/support": "5.2.*"
+    "illuminate/console": "5.2.* || 5.3.*",
+    "illuminate/database": "5.2.*@dev || 5.3.*",
+    "illuminate/events": "5.2.* || 5.3.*",
+    "illuminate/filesystem": "5.2.* || 5.3.*",
+    "illuminate/support": "5.2.* || 5.3.*"
   },
   "require-dev": {
     "phpunit/phpunit": "4.*",

--- a/src/Baum/SetMapper.php
+++ b/src/Baum/SetMapper.php
@@ -96,7 +96,7 @@ class SetMapper
      *
      * @return bool
      */
-    protected function mapTreeRecursive(array $tree, $parentKey = null, &$affectedKeys = [])
+    protected function mapTreeRecursive(array $tree, $parentKey = null, &$affectedKeys = [], $root = true)
     {
         // For every attribute entry: We'll need to instantiate a new node either
         // from the database (if the primary key was supplied) or a new instance. Then,
@@ -104,6 +104,7 @@ class SetMapper
         // present) and save it. Finally, tail-recurse performing the same
         // operations for any child node present. Setting the `parent_id` property at
         // each level will take care of the nesting work for us.
+        $sibling = null;
         foreach ($tree as $attributes) {
             $node = $this->firstOrNew($this->getSearchAttributes($attributes));
 
@@ -120,7 +121,13 @@ class SetMapper
                 return false;
             }
 
-            if (!$node->isRoot()) {
+            if($root) {
+                if($sibling) {
+                    $node->moveToRightOf($sibling);
+                }
+
+                $sibling = $node;
+            } else {
                 $node->makeLastChildOf($node->parent);
             }
 
@@ -130,7 +137,7 @@ class SetMapper
                 $children = $attributes[$this->getChildrenKeyName()];
 
                 if (count($children) > 0) {
-                    $result = $this->mapTreeRecursive($children, $node->getKey(), $affectedKeys);
+                    $result = $this->mapTreeRecursive($children, $node->getKey(), $affectedKeys, false);
 
                     if (!$result) {
                         return false;


### PR DESCRIPTION
The root nodes would never be properly reordered. Even when you pull 1 node out of a subtree and place it at the top-level, that node stays put where is was (e.g. in the subtree).
