### PR TITLE
Fix childrens array_key to children id

### DIFF
--- a/src/Baum/Extensions/Eloquent/Collection.php
+++ b/src/Baum/Extensions/Eloquent/Collection.php
@@ -37,7 +37,7 @@ class Collection extends BaseCollection
             $parentKey = $node->getParentId();
 
             if (!is_null($parentKey) && array_key_exists($parentKey, $result)) {
-                $result[$parentKey]->children[] = $node;
+                $result[$parentKey]->children[$node->id] = $node;
                 $nestedKeys[] = $node->getKey();
             }
         }


### PR DESCRIPTION
first level is associated array id=>node, but childrens is not