### PR TITLE
Fix touching of relations.

### DIFF
--- a/src/Baum/Node.php
+++ b/src/Baum/Node.php
@@ -1427,4 +1427,21 @@ abstract class Node extends Model
 
         return [$node, $nesting];
     }
+
+    /**
+     * Perform any actions that are necessary after the model is saved.
+     *
+     * @param  array  $options
+     * @return void
+     */
+    protected function finishSave(array $options)
+    {
+        $this->fireModelEvent('saved', false);
+
+        if ($options['touch'] ?? true) {
+            $this->touchOwners();
+        }
+
+        $this->syncOriginal();
+    }
 }


### PR DESCRIPTION
Due to model saved callback, dirty attributes were reset and touching of relations are not being triggered.

**Steps to reproduce:**
1. Create a model that extends the `Node`.
2. Set `$touches = ['relation']` property with some relation.

**Expected Results:**
- Relation updated_at timestamp should be updated.

**Actual Results:**
- Relation timestamp is not updated.
