### PR TITLE
Use Dispatcher Contract

### DIFF
--- a/src/Baum/Move.php
+++ b/src/Baum/Move.php
@@ -2,7 +2,7 @@
 
 namespace Baum;
 
-use Illuminate\Contracts\Events\Dispatcher
+use Illuminate\Contracts\Events\Dispatcher;
 
 /**
  * Move.

--- a/src/Baum/Move.php
+++ b/src/Baum/Move.php
@@ -2,7 +2,7 @@
 
 namespace Baum;
 
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher
 
 /**
  * Move.


### PR DESCRIPTION
Allow for the use of a dispatcher contract instead. This allows the end user to still implement their own dispatcher.